### PR TITLE
use `Translation` for dictionaries

### DIFF
--- a/frontend/src/i18n/pl/index.ts
+++ b/frontend/src/i18n/pl/index.ts
@@ -1,6 +1,6 @@
-import type { BaseTranslation } from "../i18n-types.js";
+import type { Translation } from "../i18n-types.js";
 
-const pl: BaseTranslation = {
+const pl: Translation = {
   general: {
     submit: "Potwierdź",
     cancel: "Cofnij",


### PR DESCRIPTION
You should use `Translation` here. Then you will also get notified if you have missed to translate a key or if you forgot to specify a parameter in your translations.